### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: PR Verify


### PR DESCRIPTION
Potential fix for [https://github.com/dmytro-pryvedeniuk/github-actions-dotnet/security/code-scanning/1](https://github.com/dmytro-pryvedeniuk/github-actions-dotnet/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the tasks performed in this workflow (e.g., checking out code and running tests). This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
